### PR TITLE
Add `Tynn::DefaultMatcher`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+unreleased
+----------
+
+- Add `Tynn::DefaultMatcher` plugin. This adds a catch-all matcher
+  that always execute the given block.
+
+  ```ruby
+  Tynn.define do
+    get do
+      # ...
+    end
+
+    default do # on true
+      # ...
+    end
+  end
+  ```
+
 1.4.0 (19-11-2015)
 ------------------
 

--- a/lib/tynn/default_matcher.rb
+++ b/lib/tynn/default_matcher.rb
@@ -1,0 +1,25 @@
+class Tynn
+  module DefaultMatcher
+    module InstanceMethods
+      # Public: A catch-all matcher. Always executes the given block.
+      #
+      # Examples
+      #
+      #   Tynn.define do
+      #     get do
+      #       # ...
+      #     end
+      #
+      #     default do # on true
+      #       # ...
+      #     end
+      #   end
+      #
+      def default
+        yield
+
+        halt(res.finish)
+      end
+    end
+  end
+end

--- a/test/default_matcher_test.rb
+++ b/test/default_matcher_test.rb
@@ -1,0 +1,17 @@
+require_relative "../lib/tynn/default_matcher"
+
+test "default" do |app|
+  Tynn.plugin(Tynn::DefaultMatcher)
+
+  Tynn.define do
+    default do
+      res.write("no escape")
+    end
+  end
+
+  app = Tynn::Test.new
+  app.get("/")
+
+  assert_equal 200, app.res.status
+  assert_equal "no escape", app.res.body
+end


### PR DESCRIPTION
Add `Tynn::DefaultMatcher` plugin. This adds a catch-all matcher
that always execute the given block.

```ruby
Tynn.define do
  get do
    # ...
  end

  default do # on true
    # ...
  end
end
```