### PR TITLE
Raise error if secret for session is not provided.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 unreleased
 ----------
 
+- Raise error if secret option for `Tynn::Session` is not provided:
+
+  ```
+  Tynn.plugin(Tynn::Session)
+  # => Tynn::Session::NoSecretError: No secret option provided.
+  ```
+
 - Add `Tynn::DefaultMatcher` plugin. This adds a catch-all matcher
   that always execute the given block.
 

--- a/lib/tynn/session.rb
+++ b/lib/tynn/session.rb
@@ -60,7 +60,32 @@ class Tynn
   #   )
   #
   module Session
+    NoSecretError = Class.new(RuntimeError)
+
     def self.setup(app, options = {}) # :nodoc:
+      unless options[:secret]
+        raise NoSecretError, <<-MSG.gsub(/^[ \t]{8}/, "")
+        No secret option provided.
+
+        Tynn::Session uses a secret token to sign the cookie data, thus
+        unauthorized means can't alter it. Please, add the secret option
+        to your code:
+
+            Tynn.plugin(Tynn::Session, secret: "__a_long_random_secret__", ...)
+
+        Make sure the secret is long and all random. You can generate a
+        secure secret key with:
+
+            $ ruby -r securerandom -e "puts SecureRandom.hex(64)"
+
+        If you're sharing your code publicly, make sure the secret key
+        is kept private. Knowing the secret allows an attacker to tamper
+        the data. You can use environment variables to store the secret:
+
+            Tynn.plugin(Tynn::Session, secret: ENV.fetch("SESSION_SECRET"), ...)
+        MSG
+      end
+
       if app.settings[:ssl]
         options = { secure: true }.merge(options)
       end

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -1,6 +1,12 @@
 require "securerandom"
 require_relative "../lib/tynn/session"
 
+test "raise error if secret is not given" do
+  assert_raise do
+    Tynn.plugin(Tynn::Session)
+  end
+end
+
 test "session" do
   Tynn.plugin(Tynn::Session, secret: SecureRandom.hex(64))
 


### PR DESCRIPTION
Rack::Session logs a warn message if a secret is not
provided. I think raising an error and explaining the
security concerns about this is a better default.

In the future, we can link to a Security guide in our
website.